### PR TITLE
snagrecover: fix soc_model in log file

### DIFF
--- a/src/snagrecover/cli.py
+++ b/src/snagrecover/cli.py
@@ -134,5 +134,4 @@ Templates:
 	print(f"Done recovering {soc_model} board")
 	if args.loglevel != "silent":
 		print(f"Logs were appended to {args.logfile}")
-	logger.info("Done recovering {soc_model} board")
-
+	logger.info(f"Done recovering {soc_model} board")


### PR DESCRIPTION
The debug log contains:

  2023-05-12 16:18:22,985 [INFO] Starting recovery of imx6ull board
  ...
  2023-05-12 16:18:38,456 [INFO] Done recovering {soc_model} board

Fix the missing model in the "Done" line.