### PR TITLE
Document the hidapi package needed for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ i.MX6/7/8, TI AM335x, Allwinner SUNXI and TI AM62x. Please check
 Requirements:
 
  * One of the libhidapi backends. On Debian, you can install the
-   `libhidapi-hidraw0` package or the `libhidapi-libusb0` package
+   `libhidapi-hidraw0` package or the `libhidapi-libusb0` package.
+   On OSX you can install the
+   [`hidapi`](https://formulae.brew.sh/formula/hidapi) package.
  * The ensurepip Python package. On Debian, you can install the
    python[your python version]-venv package
 


### PR DESCRIPTION
Funny enough this appears to be a lot easier to get working on OSX than on Linux(the udev rules didn't seem to work for me so I had to run as root on ubuntu).