### PR TITLE
snagrecover: imx8qxp: add to list of SDPV SoCs

### DIFF
--- a/src/snagrecover/recoveries/imx.py
+++ b/src/snagrecover/recoveries/imx.py
@@ -91,7 +91,7 @@ def main():
 	if soc_model in sdps_socs:
 		run_firmware(dev, "flash-bin", "spl-sdps")
 		# On some SoCs (e.g.: i.MX8QM) we can have a second stage based on SPDV
-		if soc_model != "imx8qm":
+		if soc_model not in ["imx8qm", "imx8qxp"]:
 			return None
 	elif "u-boot-with-dcd" in recovery_config["firmware"]:
 		run_firmware(dev, "u-boot-with-dcd")

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -23,6 +23,8 @@ tested:
         family: imx
   imx8qm:
         family: imx
+  imx8qxp:
+        family: imx
   imx93:
         family: imx
   r8:
@@ -95,8 +97,6 @@ untested:
   imx8dxl:
         family: imx
   imx8mq:
-        family: imx
-  imx8qxp:
         family: imx
   imxrt106x:
         family: imx


### PR DESCRIPTION
Add i.MX8QXP to the list of SoCs with a second stage based on SDPV.