### PR TITLE
snagrecover: udev: add STM32MP1 Fastboot device missing rule

### DIFF
--- a/docs/snagflash.md
+++ b/docs/snagflash.md
@@ -35,6 +35,8 @@ In DFU mode, snagflash takes additional arguments :
    multiple times, to specify multiple files to download.
  * `--dfu-keep`
    An optional argument to avoid detaching DFU mode after download and keep the mode active
+ * `--dfu-detach`
+   An optional argument to only request detaching DFU mode
 
 Example:
 ```bash

--- a/docs/snagflash.md
+++ b/docs/snagflash.md
@@ -25,7 +25,7 @@ can add the following udev rule to get access:
 
 ## DFU mode
 
-In DFU mode, snagflash takes two additional arguments :
+In DFU mode, snagflash takes additional arguments :
 
  * `-p --port vid:pid`
    The USB address of the DFU device exposed by U-Boot
@@ -33,6 +33,8 @@ In DFU mode, snagflash takes two additional arguments :
    The altsetting and path of a file to download to the board. This should match
    the value specified in dfu\_alt\_info in U-Boot. This flag can be passed
    multiple times, to specify multiple files to download.
+ * `--dfu-keep`
+   An optional argument to avoid detaching DFU mode after download and keep the mode active
 
 Example:
 ```bash

--- a/docs/snagflash.md
+++ b/docs/snagflash.md
@@ -37,6 +37,8 @@ In DFU mode, snagflash takes additional arguments :
    An optional argument to avoid detaching DFU mode after download and keep the mode active
  * `--dfu-detach`
    An optional argument to only request detaching DFU mode
+ * `--dfu-reset`
+   Reset USB device after download and reboot the board
 
 Example:
 ```bash

--- a/src/snagflash/cli.py
+++ b/src/snagflash/cli.py
@@ -82,8 +82,6 @@ def cli():
 
 	logger.info("Running snagflash using protocol {args.protocol}")
 	if args.protocol == "dfu":
-		if args.dfu_config is None:
-			cli_error("missing at least one DFU config!")
 		dfu_cli(args)
 	elif args.protocol == "ums":
 		if args.src is None or (args.blockdev is None and args.dest is None):

--- a/src/snagflash/cli.py
+++ b/src/snagflash/cli.py
@@ -48,6 +48,7 @@ def cli():
 	dfuargs = parser.add_argument_group("DFU")
 	dfuargs.add_argument("-D", "--dfu-config", help="The altsetting and path of a file to download to the board. in DFU mode", action="append", metavar="altsetting:path")
 	dfuargs.add_argument("--dfu-keep", help="Avoid detaching DFU mode after download and keep the mode active", action="store_true")
+	dfuargs.add_argument("--dfu-detach", help="Only request detaching DFU mode", action="store_true")
 	fbargs = parser.add_argument_group("Fastboot")
 	fbargs.add_argument("-f", "--fastboot-cmd", help="A fastboot command.", action="append", metavar="cmd:args")
 	umsargs = parser.add_argument_group("UMS")

--- a/src/snagflash/cli.py
+++ b/src/snagflash/cli.py
@@ -49,6 +49,7 @@ def cli():
 	dfuargs.add_argument("-D", "--dfu-config", help="The altsetting and path of a file to download to the board. in DFU mode", action="append", metavar="altsetting:path")
 	dfuargs.add_argument("--dfu-keep", help="Avoid detaching DFU mode after download and keep the mode active", action="store_true")
 	dfuargs.add_argument("--dfu-detach", help="Only request detaching DFU mode", action="store_true")
+	dfuargs.add_argument("--dfu-reset", help="Reset USB device after download and reboot the board", action="store_true")
 	fbargs = parser.add_argument_group("Fastboot")
 	fbargs.add_argument("-f", "--fastboot-cmd", help="A fastboot command.", action="append", metavar="cmd:args")
 	umsargs = parser.add_argument_group("UMS")

--- a/src/snagflash/cli.py
+++ b/src/snagflash/cli.py
@@ -47,6 +47,7 @@ def cli():
 	common.add_argument("--timeout", help="USB timeout, sometimes increasing this is necessary when downloading large files", default=60000)
 	dfuargs = parser.add_argument_group("DFU")
 	dfuargs.add_argument("-D", "--dfu-config", help="The altsetting and path of a file to download to the board. in DFU mode", action="append", metavar="altsetting:path")
+	dfuargs.add_argument("--dfu-keep", help="Avoid detaching DFU mode after download and keep the mode active", action="store_true")
 	fbargs = parser.add_argument_group("Fastboot")
 	fbargs.add_argument("-f", "--fastboot-cmd", help="A fastboot command.", action="append", metavar="cmd:args")
 	umsargs = parser.add_argument_group("UMS")

--- a/src/snagflash/dfu.py
+++ b/src/snagflash/dfu.py
@@ -20,7 +20,7 @@
 from snagrecover.protocols import dfu
 import logging
 logger = logging.getLogger("snagflash")
-from snagflash.utils import cli_error, get_usb
+from snagflash.utils import cli_error, get_usb, reset_usb
 from usb.core import Device
 
 def dfu_detach(dev: Device, altsetting: int = 0):
@@ -42,8 +42,13 @@ def dfu_download(dev: Device, altsetting: int, path: str):
 	dfu_cmd.get_status()
 	print("Done")
 
+def dfu_reset(dev: Device):
+	print("Sending DFU reset command...")
+	reset_usb(dev)
+	print("Done")
+
 def dfu_cli(args):
-	if args.dfu_config is None and not args.dfu_detach:
+	if args.dfu_config is None and not args.dfu_detach and not args.dfu_reset:
 		cli_error("missing command line argument --dfu-config")
 	if (args.port is None) or (":" not in args.port):
 		cli_error("missing command line argument --port [vid:pid]")
@@ -58,5 +63,7 @@ def dfu_cli(args):
 			(altsetting,sep,path) = dfu_config.partition(":")
 			altsetting = int(altsetting)
 			dfu_download(dev, altsetting, path)
-	if not args.dfu_keep or args.dfu_detach:
+	if not args.dfu_keep or args.dfu_detach or args.dfu_reset:
 		dfu_detach(dev, altsetting)
+	if args.dfu_reset:
+		dfu_reset(dev)

--- a/src/snagflash/dfu.py
+++ b/src/snagflash/dfu.py
@@ -32,23 +32,21 @@ def dfu_cli(args):
 	pid = int(dev_addr[1], 16)
 	dev = get_usb(vid, pid)
 	dev.default_timeout = int(args.timeout)
-	for dfu_config in args.dfu_config:
-		(altsetting,sep,path) = dfu_config.partition(":")
-		altsetting = int(altsetting)
-		with open(path, "rb") as file:
-			blob = file.read(-1)
-		size = len(blob)
-		print(f"Downloading {path} to altsetting {altsetting}...")
-		logger.debug(f"DFU config altsetting:{altsetting} size:0x{size:x} path:{path}")
-		dfu_cmd = dfu.DFU(dev, stm32=False)
-		dfu_cmd.get_status()
-		dfu_cmd.download_and_run(blob, altsetting, 0, size, show_progress=True)
-		dfu_cmd.get_status()
-		print("Done")
+	if args.dfu_config:
+		for dfu_config in args.dfu_config:
+			(altsetting,sep,path) = dfu_config.partition(":")
+			altsetting = int(altsetting)
+			with open(path, "rb") as file:
+				blob = file.read(-1)
+			size = len(blob)
+			print(f"Downloading {path} to altsetting {altsetting}...")
+			logger.debug(f"DFU config altsetting:{altsetting} size:0x{size:x} path:{path}")
+			dfu_cmd = dfu.DFU(dev, stm32=False)
+			dfu_cmd.get_status()
+			dfu_cmd.download_and_run(blob, altsetting, 0, size, show_progress=True)
+			dfu_cmd.get_status()
+			print("Done")
 	if not args.dfu_keep:
 		print("Sending DFU detach command...")
 		dfu_cmd.detach(altsetting)
 		print("Done")
-
-
-

--- a/src/snagflash/dfu.py
+++ b/src/snagflash/dfu.py
@@ -45,9 +45,10 @@ def dfu_cli(args):
 		dfu_cmd.download_and_run(blob, altsetting, 0, size, show_progress=True)
 		dfu_cmd.get_status()
 		print("Done")
-	print("Sending DFU detach command...")
-	dfu_cmd.detach(altsetting)
-	print("Done")
+	if not args.dfu_keep:
+		print("Sending DFU detach command...")
+		dfu_cmd.detach(altsetting)
+		print("Done")
 
 
 

--- a/src/snagflash/utils.py
+++ b/src/snagflash/utils.py
@@ -36,3 +36,9 @@ def get_usb(vid: int, pid: int) -> usb.core.Device:
 	except usb.core.USBError:
 		usb_error(vid, pid)
 	return dev
+
+def reset_usb(dev: usb.core.Device) -> None:
+	try:
+		dev.reset()
+	except usb.core.USBError:
+		pass

--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -1,4 +1,5 @@
 #ST STM32MP1 rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="0afb", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0660", TAG+="uaccess"
 
 #Microchip SAMA5 rules


### PR DESCRIPTION
The documented example to use Fastboot with a STM32MP1 board doesn't have it's related UDev default rule :

```
	Examples:
	# U-Boot: fastboot usb 0
	snagflash -P fastboot -p 0483:0afb -f download:boot.img -f flash:0:1 -f boot
	# U-Boot: ums 0 mmc 0
	snagflash -P ums -s binaries/u-boot.stm32 -b /dev/sdb1
	snagflash -P ums -s binaries/u-boot.stm32 -d /mnt/u-boot.stm32
	# U-Boot: setenv dfu_alt_info "mmc=uboot part 0 1"
	# U-Boot: dfu 0 mmc 0
	snagflash -P dfu -p 0483:df11 -D 0:binaries/u-boot.stm32
```

Follows the DFU updates PR.
Priority lower as DFU matches all STM32MP1 needs.