### PR TITLE
snagrecover: imx: add support for i.MX53

### DIFF
--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -38,6 +38,7 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="3016", ATTRS{idProduct
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="012f", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0129", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0147", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="004e", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="004f", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013e", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0146", MODE="0660", TAG+="uaccess"

--- a/src/snagrecover/config.py
+++ b/src/snagrecover/config.py
@@ -49,6 +49,7 @@ default_usb_ids =  {
 		"imxrt106x": (0x1fc9,0x0135),
 		"imx8mm": (0x1fc9,0x0134),
 		"imx8mq": (0x1fc9,0x012b),
+		"imx53" : (0x15a2,0x004e),
 	}
 }
 

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -15,6 +15,8 @@ tested:
         family: sunxi
   imx28:
         family: imx
+  imx53:
+        family: imx
   imx6q:
         family: imx
   imx6ull:


### PR DESCRIPTION
i.MX53 devices use a different version of the Serial Download Protocol.

Raw USB bulk endpoints are used rather than HID (so no report IDs)

The following commands are not implemented:
	DCD_WRITE
	JUMP_ADDRESS
	SKIP_DCD_HEADER

Replace DCD_WRITE by manually interpreting the DCD data as individual read/write commands (as imx_usb_loader does).

Tested on a custom i.MX53 based board and regression tested on a Digi Connect Core 6 i.MX6D evaluation board.