### PR TITLE
Fastboot command handling

### DIFF
--- a/src/snagflash/fastboot.py
+++ b/src/snagflash/fastboot.py
@@ -40,6 +40,6 @@ def fastboot(args):
 		cmd, args = cmd[0], cmd[1:]
 		cmd = cmd.translate({ord("-"): ord("_")})
 		print(f"Sending command {cmd} with args {args}")
-		eval(f"fast.{cmd}(*args)")
+		getattr(fast, cmd)(*args)
 	print("Done")
 

--- a/src/snagflash/fastboot.py
+++ b/src/snagflash/fastboot.py
@@ -38,7 +38,7 @@ def fastboot(args):
 	for cmd in args.fastboot_cmd:
 		cmd = cmd.split(":", 1)
 		cmd, args = cmd[0], cmd[1:]
-		cmd = cmd.translate({ord("-"): ord("_")})
+		cmd = cmd.replace("-", "_")
 		print(f"Sending command {cmd} with args {args}")
 		getattr(fast, cmd)(*args)
 	print("Done")

--- a/src/snagflash/fastboot.py
+++ b/src/snagflash/fastboot.py
@@ -36,15 +36,10 @@ def fastboot(args):
 	# this is mostly there to dodge a linter error
 	logger.debug(f"Fastboot object: eps {fast.ep_in} {fast.ep_out} packet size {fast.max_size}")
 	for cmd in args.fastboot_cmd:
-		if ":" in cmd:
-			(cmd, sep, args) = cmd.partition(":")
-		else:
-			args = None
+		cmd = cmd.split(":", 1)
+		cmd, args = cmd[0], cmd[1:]
 		cmd = cmd.translate({ord("-"): ord("_")})
 		print(f"Sending command {cmd} with args {args}")
-		if args is None:
-			eval(f"fast.{cmd}()")
-		else:
-			eval(f"fast.{cmd}(args)")
+		eval(f"fast.{cmd}(*args)")
 	print("Done")
 

--- a/src/snagflash/fastboot.py
+++ b/src/snagflash/fastboot.py
@@ -40,6 +40,8 @@ def fastboot(args):
 		cmd, args = cmd[0], cmd[1:]
 		cmd = cmd.replace("-", "_")
 		print(f"Sending command {cmd} with args {args}")
+		if cmd == "continue":
+			cmd = "fbcontinue"
 		getattr(fast, cmd)(*args)
 	print("Done")
 


### PR DESCRIPTION
A few improvements added in the process of fixing `snagflash` failing with `SyntaxError` when doing `snagflash -P fastboot -f continue`.

Most importantly, this adds a check to replace `continue` with `fbcontinue`, so the implementation matches the documentation.