### PR TITLE
snagrecover: templates: Add AM62x phyBOARD-Lyra

### DIFF
--- a/src/snagrecover/templates/am62x-phyboard-lyra.yaml
+++ b/src/snagrecover/templates/am62x-phyboard-lyra.yaml
@@ -1,0 +1,6 @@
+tiboot3:
+  path: tiboot3.bin-perif
+tispl:
+  path: tispl.bin
+u-boot:
+  path: u-boot.img


### PR DESCRIPTION
This template is for PHYTEC's phyBOARD-Lyra development kit. This kit can be used with the phyCORE-AM62x as well as phyCORE-AM62Ax SOMs. Since the BSPs for both SOMs generate the same image names, we only need one template file.