### PR TITLE
snagrecover: templates: am62x-beagle-play: Update names

### DIFF
--- a/src/snagrecover/templates/am62x-beagle-play.yaml
+++ b/src/snagrecover/templates/am62x-beagle-play.yaml
@@ -3,5 +3,5 @@ tiboot3:
 tispl:
   path: tispl.bin
 u-boot:
-  path: u-boot-play.img
+  path: u-boot.img
 


### PR DESCRIPTION
With DFU supported landed officially in U-Boot[1], we should use the same names as the instructions for mainline.

Update the Beagle Play template accordingly.

[1] https://source.denx.de/u-boot/u-boot/-/commit/def64b49374889fc3e22072af7794f4d3c446cf6
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>