### PR TITLE
src: snagrecover: templates: am62x-phyboard-lyra: Rename tiboot3

### DIFF
--- a/src/snagrecover/templates/am62x-phyboard-lyra.yaml
+++ b/src/snagrecover/templates/am62x-phyboard-lyra.yaml
@@ -1,5 +1,5 @@
 tiboot3:
-  path: tiboot3.bin-perif
+  path: tiboot3.bin-usbdfu
 tispl:
   path: tispl.bin
 u-boot:


### PR DESCRIPTION
We're not able to fit Ethernet and USB boot into one tiboot3 images. Therefore, we dropped the name "perif" and use "usbdfu" and "ethboot" now for each boot source.

Address this change of name in the phyBOARD-Lyra AM62x template.