### PR TITLE
snagrecover: move Allwinner H2+ to tested SoCs

### DIFF
--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -13,6 +13,8 @@ tested:
         family: am62x
   am62p:
         family: am62x
+  h2+:
+        family: sunxi
   h3:
         family: sunxi
   imx28:
@@ -78,8 +80,6 @@ untested:
         family: am335x
   am623:
         family: am62x
-  h2+:
-        family: sunxi
   h5:
         family: sunxi
   h6:


### PR DESCRIPTION
Tested with u-boot v2024.10 on NanoPi Duo 2