### PR TITLE
udev: Add more TI rules

### DIFF
--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -69,5 +69,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="3016", ATTRS{idProduct}=="0100", MODE="0660"
 #Allwinner SUNXI rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1f3a", ATTRS{idProduct}=="efe8", MODE="0660", TAG+="uaccess"
 
-#TI AM62x rules
+#TI rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6165", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6141", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="d022", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Add the Beagle Bone Black ROM code USB IDs as well as it's default U-Boot USB ID's. This will slightly ease the flashing on this platform which is already complex.