### PR TITLE
snagflash: add missing f-string specifier

### DIFF
--- a/src/snagflash/cli.py
+++ b/src/snagflash/cli.py
@@ -96,7 +96,7 @@ def cli():
 	recovery_logger = logging.getLogger('snagrecover')
 	recovery_logger.parent = logger
 
-	logger.info("Running snagflash using protocol {args.protocol}")
+	logger.info(f"Running snagflash using protocol {args.protocol}")
 	if args.protocol == "dfu":
 		dfu_cli(args)
 	elif args.protocol == "ums":


### PR DESCRIPTION
Hi! Thanks for making this wonderful tool. I noticed this issue when running snagflash v2.0 on Linux. 

This PR fixes a bug where the snagflash CLI would always log:

```txt
Running snagflash using protocol {args.protocol}
```

instead of logging the user-supplied protocol.