### PR TITLE
snagrecover: Add support for AM62Lx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ISP, UUU, and sunxi-fel. Snagboot is made of two separate parts:
 </p>
 
 The currently supported SoC families are ST STM32MP1/2, Microchip SAMA5, NXP
-i.MX6/7/8/93, TI AM335x, Allwinner SUNXI, TI AM62x, TI AM64x and Xilinx ZynqMP. Please check
+i.MX6/7/8/93, TI AM335x, Allwinner SUNXI, TI AM62x, TI AM64x, TI AM62Lx and Xilinx ZynqMP. Please check
 [supported_socs.yaml](https://github.com/bootlin/snagboot/blob/main/src/snagrecover/supported_socs.yaml) or run `snagrecover
 --list-socs` for a more precise list of supported SoCs.
 

--- a/docs/fw_binaries.md
+++ b/docs/fw_binaries.md
@@ -228,7 +228,7 @@ SPL part, you can typically use u-boot.img for this
 configuration:
  * path
 
-## For TI AM62x/AM62Ax/AM62Px/AM64x devices
+## For TI AM62x/AM62Ax/AM62Px/AM64x/AM62Lx devices
 
 [example](../src/snagrecover/templates/am625-beagle-play.yaml)
 
@@ -242,7 +242,9 @@ sure that your configuration supports booting from DFU.
 The following images are required for all AM6xx SoCs:
 
 **tiboot3:** X.509 certificate container with U-Boot SPL for R5, TIFS, and a FIT
-container with device tree blobs. SPL should support DFU.
+container with device tree blobs. SPL should support DFU. For AM62Lx, instead of
+U-Boot SPL for R5, it contains Pre-BL and there is no fit container with device
+tree blobs.
 
 configuration:
  * path
@@ -253,7 +255,9 @@ configuration:
  * path
 
 **tispl:** FIT container with ATF FOR A53, OPTEE (not necessary for recovery),
-DM firmware, U-Boot SPL for A53 and device tree blobs
+DM firmware, U-Boot SPL for A53 and device tree blobs. For AM62Lx, X.509 certificate
+container with ATF for A53, OPTEE, U-Boot SPL for A53, device tree blobs and
+TIFS.
 
 configuration:
  * path

--- a/src/snagrecover/config.py
+++ b/src/snagrecover/config.py
@@ -29,6 +29,7 @@ default_usb_ids =  {
 	"sama5":    "03eb:6124",
 	"sunxi":    "1f3a:efe8",
 	"am6x":     "0451:6165",
+	"am62lx":   "0451:6165",
 	"zynqmp":   "03fd:0050",
 	"imx": {
 		"imx8qxp": "1fc9:012f",

--- a/src/snagrecover/firmware/firmware.py
+++ b/src/snagrecover/firmware/firmware.py
@@ -85,6 +85,28 @@ def am6x_run(dev, fw_name: str, fw_blob: bytes):
 		logger.info("Sending detach command...")
 		dfu_cmd.detach(partid)
 
+def am62lx_run(dev, fw_name: str, fw_blob: bytes):
+	# find firmware altsetting (i.e. partition id)
+	if fw_name == "tiboot3":
+		partname = "bootloader"
+	elif fw_name == "tispl":
+		partname = "bootloader"
+	elif fw_name == "u-boot":
+		partname = "u-boot.img"
+	else:
+		cli_error(f"unsupported firmware {fw_name}")
+	logger.info("Searching for partition id...")
+	partid = dfu.search_partid(dev, partname)
+	if partid is None:
+		raise Exception(f"No DFU altsetting found with iInterface='{partname}'")
+	dfu_cmd = dfu.DFU(dev, stm32=False)
+	logger.info("Downloading file...")
+	dfu_cmd.download_and_run(fw_blob, partid, offset=0, size=len(fw_blob))
+	logger.info("Done")
+	if fw_name == "u-boot":
+		logger.info("Sending detach command...")
+		dfu_cmd.detach(partid)
+
 def run_firmware(port, fw_name: str, subfw_name: str = ""):
 	"""
 	The "subfw_name" option allows selecting firmware
@@ -119,6 +141,8 @@ def run_firmware(port, fw_name: str, subfw_name: str = ""):
 		sunxi_run(port, fw_name, fw_blob)
 	elif soc_family == "am6x":
 		am6x_run(port, fw_name, fw_blob)
+	elif soc_family == "am62lx":
+		am62lx_run(port, fw_name, fw_blob)
 	elif soc_family == "zynqmp":
 		from snagrecover.firmware.zynqmp_fw import zynqmp_run
 		zynqmp_run(port, fw_name, fw_blob, subfw_name)

--- a/src/snagrecover/recoveries/am62lx.py
+++ b/src/snagrecover/recoveries/am62lx.py
@@ -1,0 +1,28 @@
+import usb
+import logging
+logger = logging.getLogger("snagrecover")
+from snagrecover.firmware.firmware import run_firmware
+from snagrecover.utils import get_usb
+from snagrecover.config import recovery_config
+import time
+
+def send_firmware(dev, firmware):
+	run_firmware(dev, firmware)
+	# USB device should re-enumerate at this point
+	usb.util.dispose_resources(dev)
+	# without this delay, USB device will be present but not ready
+	time.sleep(1)
+
+def main():
+	usb_addr = recovery_config["usb_path"]
+	dev = get_usb(usb_addr)
+
+	send_firmware(dev, "tiboot3")
+	dev = get_usb(usb_addr)
+
+	send_firmware(dev, "tispl")
+	dev = get_usb(usb_addr)
+	time.sleep(1)
+	run_firmware(dev, "u-boot")
+
+	time.sleep(2)

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -13,6 +13,8 @@ tested:
         family: am6x
   am62p:
         family: am6x
+  am62l3:
+        family: am62lx
   h2+:
         family: sunxi
   am6442:

--- a/src/snagrecover/utils.py
+++ b/src/snagrecover/utils.py
@@ -183,6 +183,9 @@ def get_recovery(soc_family: str):
 	elif soc_family == "am6x":
 		from snagrecover.recoveries.am6x import main as am6x_recovery
 		return am6x_recovery
+	elif soc_family == "am62lx":
+		from snagrecover.recoveries.am62lx import main as am62lx_recovery
+		return am62lx_recovery
 	elif soc_family == "zynqmp":
 		from snagrecover.recoveries.zynqmp import main as zynqmp_recovery
 		return zynqmp_recovery


### PR DESCRIPTION
Add support for AM62Lx platform. The USB recovery procedure is different than the "am6x" SoC family. Update relevant docs and add AM62Lx models to the list of supported SoCs.