### PR TITLE
Intel keembay

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ISP, UUU, and sunxi-fel. Snagboot is made of two separate parts:
 </p>
 
 The currently supported SoC families are ST STM32MP1/2, Microchip SAMA5, NXP
-i.MX6/7/8/93, TI AM335x, Allwinner SUNXI, TI AM62x, TI AM64x, TI AM62Lx and Xilinx ZynqMP. Please check
+i.MX6/7/8/93, TI AM335x, Allwinner SUNXI, TI AM62x, TI AM64x, TI AM62Lx, Xilinx ZynqMP, and Intel Keembay. Please check
 [supported_socs.yaml](https://github.com/bootlin/snagboot/blob/main/src/snagrecover/supported_socs.yaml) or run `snagrecover
 --list-socs` for a more precise list of supported SoCs.
 

--- a/docs/board_setup.md
+++ b/docs/board_setup.md
@@ -56,6 +56,21 @@ the SoC is configured to boot from DFU. The SoC can also fall back to DFU if all
 other boot options fail. A few seconds after powering the board, a USB DFU
 device should appear on your host system. This can take several seconds.
 
+## Intel Keembay
+
+Intel Keembay boards have a recovery mode that can be accessed by setting
+the boot switch to the recovery position. The exact location and configuration
+of the boot switch varies by board model, so refer to your board's documentation
+for specific instructions.
+
+1. Power off the board
+2. Set the boot switch to the recovery position
+3. Connect the USB cable to the recovery port
+4. Power on the board
+
+After powering on, the board should be detected as a USB device
+with VID:PID `8087:0b39`.
+
 ## The special case of TI AM335x devices
 
 During initialization, the ROM code will set up a boot device list and for each

--- a/docs/fw_binaries.md
+++ b/docs/fw_binaries.md
@@ -290,3 +290,18 @@ extract the FSBL and PMUFW from the complete boot image.
 configuration:
  * path
 
+## For Intel Keembay devices
+
+[example](../src/snagrecover/templates/keembay-generic.yaml)
+
+Intel Keembay boards use a Firmware Image Package (FIP) to boot the board
+in recovery mode.
+
+**fip:** Firmware Image Package containing the ATF and u-boot firmware
+necessary to initialize the board.
+
+configuration:
+ * path: Path to the FIP file. The filename should match the board model:
+   - For EVM boards: `fip-evm.bin`
+   - For M2 boards: `fip-m2.bin`
+   - For HDDL2 boards: `fip-hddl2.bin`

--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -78,3 +78,6 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="d022", MODE="0660"
 
 #Xilinx rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="03fd", ATTRS{idProduct}=="0050", MODE="0660", TAG+="uaccess"
+
+#Intel Keembay rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="0b39", MODE="0660", TAG+="uaccess"

--- a/src/snagrecover/config.py
+++ b/src/snagrecover/config.py
@@ -30,6 +30,7 @@ default_usb_ids =  {
 	"am6x":     "0451:6165",
 	"am62lx":   "0451:6165",
 	"zynqmp":   "03fd:0050",
+	"keembay":  "8087:0b39",
 	"imx": {
 		"imx8qxp": "1fc9:012f",
 		"imx8qm": "1fc9:0129",

--- a/src/snagrecover/firmware/firmware.py
+++ b/src/snagrecover/firmware/firmware.py
@@ -107,6 +107,21 @@ def am62lx_run(dev, fw_name: str, fw_blob: bytes):
 		logger.info("Sending detach command...")
 		dfu_cmd.detach(partid)
 
+def keembay_run(port, fw_name: str, fw_blob: bytes):
+	if fw_name == "fip":
+		pass
+	else:
+		cli_error(f"unsupported firmware {fw_name}")
+
+	logger.info("Searching for partition id...")
+
+	fb_cmd = Fastboot(port)
+	logger.info("Downloading file...")
+	fb_cmd.download(fw_blob)
+	logger.info("Done")
+
+	return None
+
 def check_fw_blob(fw_blob: bytes):
 	"""
 	Do a quick sanity check on the firmware contents.  If the file passed
@@ -159,6 +174,8 @@ def run_firmware(port, fw_name: str, subfw_name: str = ""):
 		sama5_run(port, fw_name, fw_blob)
 	elif soc_family == "stm32mp":
 		stm32mp_run(port, fw_name, fw_blob)
+	elif soc_family == "keembay":
+		keembay_run(port, fw_name, fw_blob)
 	elif soc_family == "imx":
 		from snagrecover.firmware.imx_fw import imx_run
 		imx_run(port, fw_name, fw_blob, subfw_name)

--- a/src/snagrecover/recoveries/keembay.py
+++ b/src/snagrecover/recoveries/keembay.py
@@ -1,0 +1,33 @@
+# This file is part of Snagboot
+# Copyright (C) 2025 Luxonis
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import time
+import logging
+from snagrecover.config import recovery_config
+from snagrecover.utils import access_error, get_usb, prettify_usb_addr
+from snagrecover.firmware.firmware import run_firmware
+from snagrecover.protocols.fastboot import Fastboot
+
+logger = logging.getLogger("snagrecover")
+
+def main():
+    # USB ENUMERATION
+    usb_addr = recovery_config["usb_path"]
+    usb_dev = get_usb(usb_addr)
+
+    # Download FIP
+    run_firmware(usb_dev, "fip")

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -43,6 +43,8 @@ tested:
         family: imx
   imx93:
         family: imx
+  keembay:
+        family: keembay
   r8:
         family: sunxi
   sama5d2:
@@ -146,4 +148,3 @@ untested:
         family: sunxi
   v853:
         family: sunxi
-

--- a/src/snagrecover/templates/keembay-generic.yaml
+++ b/src/snagrecover/templates/keembay-generic.yaml
@@ -1,0 +1,2 @@
+fip:
+  path: ./fip.bin

--- a/src/snagrecover/utils.py
+++ b/src/snagrecover/utils.py
@@ -195,6 +195,9 @@ def get_recovery(soc_family: str):
 	elif soc_family == "zynqmp":
 		from snagrecover.recoveries.zynqmp import main as zynqmp_recovery
 		return zynqmp_recovery
+	elif soc_family == "keembay":
+		from snagrecover.recoveries.keembay import main as keembay_recovery
+		return keembay_recovery
 	else:
 		cli_error(f"unsupported board family {soc_family}")
 


### PR DESCRIPTION
These patches add support for Intel Keembay SoC.

The SoC boots from eMMC ATF+u-boot stored in the boot bank and with support for the fastboot protocol.