### PR TITLE
50-snagboot.rules: add support for "Toradex USB download gadget"

### DIFF
--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -35,6 +35,7 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0152", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0159", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="3016", ATTRS{idProduct}=="0100", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b67", ATTRS{idProduct}=="4fff", MODE="0660", TAG+="uaccess"
 
 #NXP i.MX rules for libusb backend
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="012f", MODE="0660", TAG+="uaccess"
@@ -67,6 +68,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0151", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0152", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0159", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3016", ATTRS{idProduct}=="0100", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1b67", ATTRS{idProduct}=="4fff", MODE="0660", TAG+="uaccess"
 
 #Allwinner SUNXI rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1f3a", ATTRS{idProduct}=="efe8", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Tested on Toradex Verdin iMX8MM Mini V1.1D in Dahlia V1.1D carrier board