### PR TITLE
(supported_socs): add TI am62d soc in am62x family.

### DIFF
--- a/docs/board_setup.md
+++ b/docs/board_setup.md
@@ -49,7 +49,7 @@ booting from FEL mode. On some models, this will happen automatically. On
 others, further setup is required. We recommend that you check your board
 vendor's user guide.
 
-## TI AM62x / TI AM62Ax / TI AM62Px
+## TI AM62x / TI AM62Ax / TI AM62Px / TI AM62Dx
 
 Connect the USB device port to your host PC. Power your board, making sure that
 the SoC is configured to boot from DFU. The SoC can also fall back to DFU if all

--- a/docs/fw_binaries.md
+++ b/docs/fw_binaries.md
@@ -229,7 +229,7 @@ SPL part, you can typically use u-boot.img for this
 configuration:
  * path
 
-## For TI AM62x/AM62Ax/AM62Px/AM64x/AM62Lx devices
+## For TI AM62x/AM62Ax/AM62Px/AM64x/AM62Lx/AM62Dx devices
 
 [example](../src/snagrecover/templates/am625-beagle-play.yaml)
 

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -11,6 +11,8 @@ tested:
         family: am6x
   am62a7:
         family: am6x
+  am62d2:
+        family: am6x
   am62p:
         family: am6x
   am62l3:


### PR DESCRIPTION
Linux support for TI am62d soc has been added and
adding it in supported socs for snagboot support.