### PR TITLE
README.md: improve the presentation of the list of SoC supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ ISP, UUU, and sunxi-fel. Snagboot is made of two separate parts:
   <img src="docs/tutorial_snagrecover.gif" alt="animated" />
 </p>
 
-The currently supported SoC families are ST STM32MP1/2, Microchip SAMA5, NXP
-i.MX6/7/8/93, TI AM335x, Allwinner SUNXI, TI AM62x, TI AM64x, TI AM62Lx, Xilinx ZynqMP, and Intel Keembay. Please check
+Snagbot currently supports the following families of System-On-Chips (SoCs):
+
+ * [Allwinner sunxi](https://linux-sunxi.org/) A10, A10S, A13, A20, A23, A31, A33, A63, A64, A80, A83T, AF1C100S, H2+, R8, R16, R40, R329, R528, T113-S3, V3S, V5S, V536, V831, V853
+ * [STMicroelectronics](http://st.com/) [STM32MP1](https://www.st.com/en/microcontrollers-microprocessors/stm32mp1-series.html) and [STM32MP2](https://www.st.com/en/microcontrollers-microprocessors/stm32mp2-series.html)
+ * [Microchip](https://www.microchip.com/) [SAMA5](https://www.microchip.com/en-us/products/microprocessors/32-bit-mpus/sama5)
+ * [NXP](https://www.nxp.com/) [i.MX6](https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors/i-mx-6-processors:IMX6X_SERIES), [i.MX7](https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors/i-mx-7-processors:IMX7-SERIES), [i.MX8](https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors/i-mx-8-applications-processors:IMX8-SERIES), [i.MX93](https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors/i-mx-9-processors/i-mx-93-applications-processor-family-arm-cortex-a55-ml-acceleration-power-efficient-mpu:i.MX93)
+ * [Texas Instruments](https://www.ti.com) [AM335x](https://www.ti.com/product/AM3358), [AM62x](https://www.ti.com/product/AM625), [AM62Lx](https://www.ti.com/product/AM62L), [AM64x](https://www.ti.com/product/AM6442)
+ * [Xilinx/AMD](https://www.amd.com/) [Zynq UltraScale+ MPSoC](https://www.amd.com/en/products/adaptive-socs-and-fpgas/soc/zynq-ultrascale-plus-mpsoc.html)
+ * [Intel](https://www.intel.com/) Keembay
+
+Please check
 [supported_socs.yaml](https://github.com/bootlin/snagboot/blob/main/src/snagrecover/supported_socs.yaml) or run `snagrecover
 --list-socs` for a more precise list of supported SoCs.
 


### PR DESCRIPTION
So far, the list of SoC support was not very well presented, almost a bit hidden, while it is a major feature of Snagboot that it supports many different platforms.

Make this a little bit more prominent by using a bullet point list, adding links, listing more exhaustively the supported platforms.