### PR TITLE
Add recovery for Broadcom bcm2711 and bcm2712

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ISP, UUU, and sunxi-fel. Snagboot is made of two separate parts:
   <img src="docs/tutorial_snagrecover.gif" alt="animated" />
 </p>
 
-Snagbot currently supports the following families of System-On-Chips (SoCs):
+Snagboot currently supports the following families of System-On-Chips (SoCs):
 
  * [Allwinner sunxi](https://linux-sunxi.org/) A10, A10S, A13, A20, A23, A31, A33, A63, A64, A80, A83T, AF1C100S, H2+, R8, R16, R40, R329, R528, T113-S3, V3S, V5S, V536, V831, V853
  * [STMicroelectronics](http://st.com/) [STM32MP1](https://www.st.com/en/microcontrollers-microprocessors/stm32mp1-series.html) and [STM32MP2](https://www.st.com/en/microcontrollers-microprocessors/stm32mp2-series.html)
@@ -24,10 +24,11 @@ Snagbot currently supports the following families of System-On-Chips (SoCs):
  * [Texas Instruments](https://www.ti.com) [AM335x](https://www.ti.com/product/AM3358), [AM62x](https://www.ti.com/product/AM625), [AM62Lx](https://www.ti.com/product/AM62L), [AM64x](https://www.ti.com/product/AM6442)
  * [Xilinx/AMD](https://www.amd.com/) [Zynq UltraScale+ MPSoC](https://www.amd.com/en/products/adaptive-socs-and-fpgas/soc/zynq-ultrascale-plus-mpsoc.html)
  * [Intel](https://www.intel.com/) Keembay
+ * [Broadcom](https://www.broadcom.com/) BCM2711 and BCM2712, used in [Raspberry Pi 4 & 5](https://www.raspberrypi.com/documentation/computers/processors.html)
 
-Please check
-[supported_socs.yaml](https://github.com/bootlin/snagboot/blob/main/src/snagrecover/supported_socs.yaml) or run `snagrecover
---list-socs` for a more precise list of supported SoCs.
+
+Please check [supported_socs.yaml](https://github.com/bootlin/snagboot/blob/main/src/snagrecover/supported_socs.yaml)
+or run `snagrecover --list-socs` for a more precise list of supported SoCs.
 
 ## Installation on Linux
 

--- a/docs/board_setup.md
+++ b/docs/board_setup.md
@@ -151,3 +151,7 @@ sudo am335x_usb_setup.sh -c
 **Note:** If for some reason, the am335x_usb_setup.sh script exits without
 cleaning up the network namespace and polling subprocess, you can run the above
 command to remove them.
+
+## Broadcom BCM
+
+Set up your board in "USB device boot mode", connect the board to the USB device port, power the board if necessary. A new USB device should appear on your host system.

--- a/docs/fw_binaries.md
+++ b/docs/fw_binaries.md
@@ -305,3 +305,50 @@ configuration:
    - For EVM boards: `fip-evm.bin`
    - For M2 boards: `fip-m2.bin`
    - For HDDL2 boards: `fip-hddl2.bin`
+
+
+## For Broadcom BCM devices
+
+[example](../src/snagrecover/templates/bcm2711.yaml)
+
+In the case of Raspberry Pi, most firmwares can be found in their GitHub repositories [github.com/raspberrypi](https://github.com/raspberrypi/)
+along with a [genimage.cfg](https://github.com/raspberrypi/buildroot/blob/mass-storage-gadget64/board/raspberrypi64-mass-storage-gadget/genimage.cfg) file wich can be taken as a reference for building the DOS partition image using the [genimage](https://github.com/pengutronix/genimage) tool.
+
+
+**bootfiles:** tar archive containing the FSBL and some of the firmwares required by the FSBL to boot U-Boot. Firmwares can optionally be located inside of a subfolder, named 2711|2712 for bcm2711|bcm2712 respectively.
+ - bootcode\<n>.bin: the FSBL, which acts as USB client requesting firmware to load. For bootcode, \<n> is 4|5 for bcm2711|bcm2712 respectively.
+ - mcb.bin: RAM init
+ - memsys\<nn>.bin: more RAM inits
+ - bootmain: the loader for the disk image
+
+In the case of Raspberry Pi, a ready made "bootfiles" firmware can be found [here](https://github.com/raspberrypi/usbboot/commit/798ea2ef893bfa11fe3dba0e088cbc9b862184a1).
+
+configuration:
+ * path
+
+
+**boot:** DOS partition table image with the first partition bootable with a FAT filesystem containing:
+ - \<board>.dtb: the compiled device tree, loaded in memory by `start<n>.elf` and used by U-Boot
+ - \<board>.dtbo: the device tree overlays
+ - config.txt: a file which specifies to `start<n>.elf` to boot U-Boot proper instead of Linux (`kernel=u-boot.bin`) and to start in 64 bits mode (`arm_64bit=1`)
+ - cmdline.txt: linux kernel command line, as we don't boot linux you can keep it empty.
+ - start\<n>.elf: the SSBL
+ - fixup\<n>.dat: the SSBL linker file (found in pair with start\<n>.elf)
+ - U-Boot proper (`u-boot.bin`)
+
+ This DOS partition image can be generated using the `genimage` tool. In the case of Raspberry Pi, [ready made images already exists](https://github.com/raspberrypi/usbboot/blob/master/mass-storage-gadget64/boot.img), however they do not contain a U-Boot but a Linux. **If you use them, you must provide U-Boot separately using the "u-boot" firmware section**. In that case, Snagrecover will create a temporary copy of it and do what is necessary to boot U-Boot instead of Linux.
+
+configuration:
+ * path
+
+
+**config:** config text file with parameter to setup the board to boot from RAM (`boot_ramdisk=1`)
+
+configuration:
+ * path
+
+
+**u-boot:** (optional) U-Boot proper. You can use this option if you want Snagrecover to modify **boot** firmware to add U-Boot to it (this is mandatory if you are using a ready-made **boot** firmware from RPi). If your **boot** firmware already contains a U-Boot, you can skip this option.
+
+configuration:
+  * path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
 	"tftpy >= 0.8.2",
 	"crccheck >= 1.3.0",
 	"pylibfdt >= 1.7.2.post1",
-	"packaging >= 24.2"
+	"packaging >= 24.2",
+	"pyfatfs >= 1.1.0",
 ]
 
 [project.urls]

--- a/src/snagrecover/50-snagboot.rules
+++ b/src/snagrecover/50-snagboot.rules
@@ -81,3 +81,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="03fd", ATTRS{idProduct}=="0050", MODE="0660"
 
 #Intel Keembay rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="0b39", MODE="0660", TAG+="uaccess"
+
+#Broadcom rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0a5c", ATTRS{idProduct}=="2711", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0a5c", ATTRS{idProduct}=="2712", MODE="0660", TAG+="uaccess"

--- a/src/snagrecover/config.py
+++ b/src/snagrecover/config.py
@@ -61,6 +61,7 @@ default_usb_ids = {
 		"imx8mq": "1fc9:012b",
 		"imx53": "15a2:004e",
 	},
+	"bcm": {"bcm2711": "0a5c:2711", "bcm2712": "0a5c:2712"},
 }
 
 recovery_config = {}  # Global immutable config to be initialized with CLI args
@@ -90,10 +91,9 @@ def init_config(args: list):
 
 	if soc_family != "am335x":
 		if args.usb_path is None:
-			if soc_family == "imx":
-				usb_ids = default_usb_ids["imx"][soc_model]
-			else:
-				usb_ids = default_usb_ids[soc_family]
+			usb_ids = default_usb_ids[soc_family]
+			if isinstance(usb_ids, dict):
+				usb_ids = usb_ids[soc_model]
 
 			recovery_config["usb_path"] = usb_addr_to_path(usb_ids)
 

--- a/src/snagrecover/firmware/bcm.py
+++ b/src/snagrecover/firmware/bcm.py
@@ -1,0 +1,416 @@
+import logging
+import tarfile
+import struct
+
+logger = logging.getLogger("snagrecover")
+
+from dataclasses import dataclass
+from snagrecover.utils import BinFileHeader
+from fs import open_fs, errors
+from pyfatfs import PyFATException
+from io import BytesIO
+from pathlib import Path
+from os.path import normpath
+from tempfile import TemporaryDirectory
+from shutil import copy2
+from time import sleep
+from contextlib import nullcontext
+from snagrecover.firmware.firmware import load_fw, get_fw_path
+from snagrecover.protocols.bcm import (
+	rom_code_send_file,
+	BootcodeCommand,
+	bootcode_get_command,
+	bootcode_send_file_size,
+	bootcode_send_file,
+)
+from snagrecover.config import recovery_config
+
+
+def tar_getmember(tar: bytes | tarfile.TarFile, member_path: str) -> tarfile.TarInfo:
+	"""
+	return member (TarInfo) from tar archive.
+
+	raise KeyError if member_path is not found in tar  archive.
+	"""
+
+	if isinstance(tar, tarfile.TarFile):
+		bytes_context = nullcontext()
+		tar_context = nullcontext(tar)
+	else:
+		bytes_context = BytesIO(tar)
+		tar_context = tarfile.open(fileobj=bytes_context)
+
+	with bytes_context, tar_context as tar_file:
+		members_names = tar_file.getnames()
+
+		# tar archive allows to update a file without recreating all the archive.
+		# To do so, it append the new version to the archive, keeping the old version inside the archive.
+		# We want to have the last version of a given file, look at lastly added file first (reverse).
+		members_names.reverse()
+		if len(members_names) == 0:
+			err_msg = f"tar archive is empty, can't contain '{member_path}'"
+			logger.warning(err_msg)
+			raise KeyError(err_msg)
+
+		for member_name in members_names:
+			# Fix an "issue" where `tar_file.getmember("bootcode4.bin")` doesn't find "./bootcode4.bin" (and vice versa) inside the archive.
+			# Depending on how you create the tar archive, file can be prepended with "./".
+			if normpath(member_path) == normpath(member_name):
+				if member_path != member_name:
+					logger.debug(
+						f"Tar member '{member_name}' match '{member_path}' using normalized path '{normpath(member_path)}'"
+					)
+				return tar_file.getmember(member_name)
+
+		_norm_path = (
+			f" ({normpath(member_path)})"
+			if normpath(member_path) != member_path
+			else ""
+		)
+		raise KeyError(f"{member_path}{_norm_path} is not present in the tar archive")
+
+
+def tar_member_exist(tar: bytes | tarfile.TarFile, member_path: str) -> bool:
+	"""
+	Test if member_path is present in the given archive.
+	"""
+	file_exists = False
+	try:
+		tar_getmember(tar, member_path)
+		file_exists = True
+	except KeyError:
+		pass
+
+	return file_exists
+
+
+def tar_extract_file(tar_blob: bytes, file_path: str) -> bytes:
+	"""
+	Extract file_path from tar_blob tar archive. file_path must point to a file/link inside tar_blob.
+	raise ValueError if file_path is not a file/link (ie if extractfile returns None)
+	"""
+	with (
+		BytesIO(tar_blob) as bootfiles_bin_file,
+		tarfile.open(fileobj=bootfiles_bin_file) as tar_file,
+	):
+		member = tar_getmember(tar_file, file_path)
+		member = tar_file.extractfile(member)
+		if member is None:
+			raise ValueError(
+				f"{file_path} exists in tar archive but is is not a file or link"
+			)
+		file_bytes = member.read(-1)
+
+	return file_bytes
+
+
+def get_fileblob_from_bootfiles(
+	tar_blob: bytes, file_name: str, file_paths: [str]
+) -> bytes:
+	"""
+	tar_blob: bootfiles tar archive
+	file_name: name of file, used for logging
+	file_paths: paths to look for file_name inside the tar archive
+	"""
+	logger.debug(f"Searching for {file_paths} in 'bootfiles'")
+	file_exist_paths = [x for x in file_paths if tar_member_exist(tar_blob, x)]
+	logger.debug(f"Found {file_exist_paths} in 'bootfiles'")
+	if len(file_exist_paths) == 0:
+		err_msg = (
+			f"'bootfiles' tar archive doesn't contain '{file_name}' ({file_paths})"
+		)
+		logger.critical(err_msg)
+		raise FileNotFoundError(err_msg)
+
+	file_path = file_exist_paths[0]
+	if len(file_exist_paths) == 2:
+		err_msg = f"Found two {file_name} in 'bootfiles' ({file_exist_paths})"
+		logger.critical(err_msg)
+		raise Exception(err_msg)
+
+	logger.debug(f"Extracting '{file_name}' from 'bootfiles'...")
+	try:
+		return tar_extract_file(tar_blob, file_path)
+	except ValueError as ve:
+		err_msg = f"'bootfile'/{file_path} exists but is is not a file or link"
+		logger.critical(err_msg)
+		ve.add_note(err_msg)
+		raise ve
+	except tarfile.TarError as te:
+		err_msg = f"Error when trying to extract 'bootfiles'/{file_path}"
+		logger.critical(err_msg)
+		te.add_note(err_msg)
+		raise te
+
+
+@dataclass
+class MBR(BinFileHeader):
+	bootstrap_code: bytes
+	partition_entry_1: bytes
+	partition_entry_2: bytes
+	partition_entry_3: bytes
+	partition_entry_4: bytes
+	boot_signature: int
+
+	fmt = "< 446s 16s 16s 16s 16s H"
+	class_size = 512
+
+	SECTOR_SIZE = 512
+	BOOT_SIGNATURE = 0xAA55
+
+	def is_valid(self) -> bool:
+		return self.boot_signature == MBR.BOOT_SIGNATURE
+
+
+@dataclass
+class PartitionEntry(BinFileHeader):
+	status: int
+	chs_first_sector: bytes
+	_type: int
+	chs_last_sector: bytes
+	lba_first_sector: int
+	lba_nb_sectors: int
+
+	fmt = "< B 3s B 3s I I"
+	class_size = 16
+
+	STATUS_ACTIVE_BIT = 7
+	FAT_LBA_COMPATIBLE = [
+		0x01,  # FAT12 (CHS/LBA)
+		0x04,  # FAT16 (CHS/LBA)
+		0x06,  # FAT12/16 (CHS/LBA)
+		0x0B,  # FAT32 (CHS/LBA)
+		0x0C,  # FAT32 (LBA)
+		0x0E,  # FAT12/16 (LBA)
+	]
+
+	def is_active(self) -> bool:
+		return self.status & (1 << PartitionEntry.STATUS_ACTIVE_BIT)
+
+	def is_fat_lba(self) -> bool:
+		return self.is_active() and self._type in PartitionEntry.FAT_LBA_COMPATIBLE
+
+	def get_fat_start_offset(self) -> int:
+		"""
+		Get partition start offset in bytes.
+		Partition type must be FAT with LBA.
+
+		raise ValueError if is partition is not active or partition is not FAT with LBA.
+		"""
+		if self.is_fat_lba():
+			return self.lba_first_sector * MBR.SECTOR_SIZE
+		else:
+			if self.is_active():
+				raise ValueError(
+					f"Partition type ({self._type:#04x}) is not FAT with LBA ([{','.join(f'{i:#04x}' for i in PartitionEntry.FAT_LBA_COMPATIBLE)}])"
+				)
+			else:
+				raise ValueError(
+					f"Partition is not active (partition status: {self.status:#04x})"
+				)
+
+	def __str__(self) -> str:
+		return f"status: {self.status:#04x}, type: {self._type:#04x}, lba_first_sector: {self.lba_first_sector:#010x}({self.lba_first_sector}), lba_nb_sectors: {self.lba_first_sector:#010x}({self.lba_first_sector}) "
+
+
+def should_modify_boot_fw() -> bool:
+	return "u-boot" in recovery_config["firmware"]
+
+
+def modify_boot_fw(boot_path: str, uboot_blob: bytes) -> None:
+	"""
+	Modify 'boot_path' disk image (MBR + FAT) to add U-Boot,
+	remove Linux if present. Update config.txt settings' accordingly.
+	"""
+	logger.debug(f"Reading MBR from 'boot' firmware ({boot_path})")
+	with open(boot_path, "rb") as bootimg:
+		mbr_blob = bootimg.read(MBR.class_size)
+
+	try:
+		mbr = MBR.read(mbr_blob)
+	except struct.error as se:
+		logger.critical(f"Unexpected error while parsing MBR: {se}")
+		raise se
+
+	if not (mbr.is_valid()):
+		err_msg = f"Invalid MBR in 'boot' firmware (MBR signature: {mbr.boot_signature} != {MBR.BOOT_SIGNATURE})"
+		logger.critical(err_msg)
+		raise Exception(err_msg)
+
+	logger.debug(f"Parsing first partition entry ({mbr.partition_entry_1})")
+	try:
+		partition1 = PartitionEntry.read(mbr.partition_entry_1)
+	except struct.error as se:
+		logger.critical(f"Unexpected error while parsing first partition entry: {se}")
+		raise se
+
+	try:
+		first_partition_offset = partition1.get_fat_start_offset()
+		logger.debug(
+			f"First partition FAT byte offset's: {first_partition_offset:#x} ({first_partition_offset})"
+		)
+	except ValueError as ve:
+		logger.critical(ve)
+		raise ve
+
+	with open_fs(f"fat://{boot_path}?offset={first_partition_offset}") as bootimgfs:
+		# IMPROVE fetch kernel path from config.txt
+		# Workarround: existing files name are uppercased because they are not found otherwise (FAT SFN)
+		kernel_path = "kernel8.img".upper()
+		try:
+			# removing kernel is optional but we might need the freed space
+			# if more size is needed in future, can also delete initramfs (and remove it from settings)
+			bootimgfs.remove(kernel_path)
+			logger.debug(f"Removed '{kernel_path}' from 'boot' firmware ({boot_path})")
+		except errors.ResourceNotFound:
+			logger.debug(f"Can't delete '{kernel_path}'from 'boot' firmware: not found")
+
+		uboot_path = "u-boot.bin"
+		logger.debug(f"Writting '{uboot_path}' in 'boot' firmware ({boot_path})")
+		try:
+			bootimgfs.writebytes(uboot_path, uboot_blob)
+		except PyFATException as pfe:
+			err_msg = "Error when trying to add U-Boot to 'boot' firmware"
+			logger.critical(err_msg)
+			pfe.add_note(err_msg)
+			raise pfe
+
+		logger.debug(f"Updating 'config.txt' in 'boot' firmware ({boot_path})")
+		config_path = "config.txt".upper()
+		try:
+			content = bootimgfs.readtext(config_path)
+		except PyFATException as pfe:
+			err_msg = f"Error while trying to read '{config_path}' from 'boot' firmware: {pfe}"
+			logger.critical(err_msg)
+			raise pfe
+
+		# the last occurence of a settings is actually the one used
+		content += "\n# Start of settings added by snagrecover\n"
+		content += "[all]\n"
+		content += "kernel=u-boot.bin\n"
+		content += "arm_64bit=1\n"
+		content += "# End of settings added by snagrecover\n"
+
+		try:
+			bootimgfs.writetext(config_path, content)
+		except PyFATException as pfe:
+			err_msg = (
+				f"Error while trying to modify '{config_path}' from 'boot' firmware"
+			)
+			logger.critical(err_msg)
+			pfe.add_note(err_msg)
+			raise pfe
+
+		logger.debug(f"Updated config.txt content's : {content.replace('\n', '\\n')}")
+		logger.debug(f"'boot' firmware '/' directory content: {bootimgfs.listdir('/')}")
+
+
+def bcm_run(port, fw_name: str, fw_blob: bytes, subfw_name: str) -> None:
+	if fw_name != "bootfiles":
+		# sanity check, right now we only have 'bootfiles' firmware
+		err_msg = f"Unexpected firmware '{fw_name}'"
+		logger.critical(err_msg)
+		raise ValueError(err_msg)
+
+	tar_blob = fw_blob
+	soc_model = recovery_config["soc_model"]
+	if soc_model == "bcm2711":
+		subfolder_name = "2711"
+		bootcode_name = "bootcode4.bin"
+	elif soc_model == "bcm2712":
+		subfolder_name = "2712"
+		bootcode_name = "bootcode5.bin"
+	else:
+		# sanity check
+		raise ValueError(f"Unexpected {soc_model=}")
+
+	if subfw_name == "bootcode":
+		bootcode_paths = [f"{subfolder_name}/{bootcode_name}", bootcode_name]
+		bootcode_blob = get_fileblob_from_bootfiles(
+			tar_blob, bootcode_name, bootcode_paths
+		)
+
+		logger.info(f"Sending 'bootfiles'/{bootcode_name} to ROM Code...")
+		if transfer_res := rom_code_send_file(port, bootcode_blob):
+			err_msg = f"Failed transfer of 'bootfiles' {bootcode_name} to ROM Code with status: {transfer_res}"
+			logger.critical(err_msg)
+			raise Exception(err_msg)
+
+	elif subfw_name == "bootcode_firmwares":
+		# Also handle firmwares 'boot' and 'u-boot'
+		"""
+		bootcode functions as a file client. It issues requests (GET_FILE_SIZE, GET_FILE) that we must serve.
+
+		Procedure is as follows:
+		1. get command and file name (bootcode_get_command)
+		2. GET_FILE_SIZE command: send file size (bootcode_send_file_size)
+		3. GET_FILE command: send file (bootcode_send_file)
+		4. repeat above steps until DONE command
+		"""
+
+		if should_modify_boot_fw():
+			boot_fw_path = get_fw_path("boot")
+			tempdir = TemporaryDirectory()
+			boot_fw_path_copy = copy2(boot_fw_path, f"{tempdir.name}/boot.img")
+			logger.info(
+				"U-Boot found in recovery config, copying 'boot' firmware and update it"
+			)
+			uboot_blob = load_fw("u-boot")
+			modify_boot_fw(boot_fw_path_copy, uboot_blob)
+		else:
+			logger.debug(
+				"U-Boot not found in recovery config, use unmodified 'boot' firmware"
+			)
+
+		logger.info("Serving bootcode requests...")
+		command, file_name = bootcode_get_command(port)
+		previous_file_name, previous_fw_blob = None, None
+		while command != BootcodeCommand.DONE:
+			logger.debug(
+				f"Serving command '{command!r}' on requested file '{file_name}'"
+			)
+
+			if file_name == previous_file_name:
+				# We expect GET_FILE_SIZE then GET_FILE on the same file, save us from reloading the blob
+				requested_fw_blob = previous_fw_blob
+			elif file_name in ["boot.img", "config.txt"]:
+				firmware_name = Path(file_name).stem
+				if firmware_name == "boot" and should_modify_boot_fw():
+					file_path = boot_fw_path_copy
+					requested_fw_blob = Path(file_path).read_bytes()
+				else:
+					file_path = get_fw_path(firmware_name)
+					requested_fw_blob = load_fw(
+						firmware_name, check_fw=(file_name != "config.txt")
+					)
+				logger.debug(
+					f"'Requested file is '{file_name}', using firmware '{firmware_name}' ({file_path})"
+				)
+			else:
+				file_paths = [f"{subfolder_name}/{file_name}", file_name]
+				requested_fw_blob = get_fileblob_from_bootfiles(
+					tar_blob, file_name, file_paths
+				)
+
+			if command == BootcodeCommand.GET_FILE_SIZE:
+				bootcode_send_file_size(port, requested_fw_blob)
+			elif command == BootcodeCommand.GET_FILE:
+				bootcode_send_file(port, requested_fw_blob)
+				logger.info(f"Served requested file for '{file_name}'")
+				if file_name == "boot.img":
+					logger.info("Waiting for 'boot' firmware to load...")
+					sleep(3)
+
+			previous_file_name, previous_fw_blob = file_name, requested_fw_blob
+			(command, file_name) = bootcode_get_command(port)
+
+		logger.info("Done serving bootcode requests")
+		if should_modify_boot_fw():
+			logger.debug(f"Cleanup temporary files ({boot_fw_path})")
+			tempdir.cleanup()
+
+	else:
+		# sanity check
+		err_msg = f"Unexpected firmware '{fw_name}'"
+		logger.critical(err_msg)
+		raise ValueError(err_msg)

--- a/src/snagrecover/firmware/firmware.py
+++ b/src/snagrecover/firmware/firmware.py
@@ -159,12 +159,12 @@ def get_fw_path(fw_name: str) -> str:
 		fw_path = fw["path"]
 	except KeyError:
 		cli_error(
-			f"Could not find firmware {fw_name} path's in recovery config, please check your recovery config"
+			f"Could not find firmware {fw_name} path in recovery config, please check your recovery config"
 		)
 	return fw_path
 
 
-def load_fw(fw_name: str, check_fw: bool =True) -> bytes:
+def load_fw(fw_name: str, check_fw: bool = True) -> bytes:
 	fw_path = get_fw_path(fw_name)
 
 	with open(fw_path, "rb") as file:
@@ -219,6 +219,10 @@ def run_firmware(port, fw_name: str, subfw_name: str = ""):
 		from snagrecover.firmware.zynqmp_fw import zynqmp_run
 
 		zynqmp_run(port, fw_name, fw_blob, subfw_name)
+	elif soc_family == "bcm":
+		from snagrecover.firmware.bcm import bcm_run
+
+		bcm_run(port, fw_name, fw_blob, subfw_name)
 	else:
 		raise Exception(f"Unsupported SoC family {soc_family}")
 	logger.info(f"Done installing firmware {fw_name}")

--- a/src/snagrecover/firmware/firmware.py
+++ b/src/snagrecover/firmware/firmware.py
@@ -148,13 +148,24 @@ def check_fw_blob(fw_blob: bytes):
 	return False
 
 
-def load_fw(fw_name: str, check_fw=True) -> bytes:
+def get_fw_path(fw_name: str) -> str:
 	try:
-		fw_path = recovery_config["firmware"][fw_name]["path"]
+		fw = recovery_config["firmware"][fw_name]
 	except KeyError:
 		cli_error(
-			f"Could not find firmware {fw_name}, please check your recovery config"
+			f"Could not find firmware {fw_name} in recovery_config, please check your recovery config"
 		)
+	try:
+		fw_path = fw["path"]
+	except KeyError:
+		cli_error(
+			f"Could not find firmware {fw_name} path's in recovery config, please check your recovery config"
+		)
+	return fw_path
+
+
+def load_fw(fw_name: str, check_fw: bool =True) -> bytes:
+	fw_path = get_fw_path(fw_name)
 
 	with open(fw_path, "rb") as file:
 		fw_blob = file.read(-1)

--- a/src/snagrecover/firmware/firmware.py
+++ b/src/snagrecover/firmware/firmware.py
@@ -148,7 +148,7 @@ def check_fw_blob(fw_blob: bytes):
 	return False
 
 
-def load_fw(fw_name: str):
+def load_fw(fw_name: str, check_fw=True) -> bytes:
 	try:
 		fw_path = recovery_config["firmware"][fw_name]["path"]
 	except KeyError:
@@ -159,7 +159,7 @@ def load_fw(fw_name: str):
 	with open(fw_path, "rb") as file:
 		fw_blob = file.read(-1)
 
-	if not check_fw_blob(fw_blob):
+	if check_fw and not check_fw_blob(fw_blob):
 		logger.warning(f"File {fw_path} looks like a text file!")
 
 	return fw_blob

--- a/src/snagrecover/protocols/bcm.py
+++ b/src/snagrecover/protocols/bcm.py
@@ -1,0 +1,155 @@
+import logging
+import enum
+
+logger = logging.getLogger("snagrecover")
+from time import sleep
+from snagrecover.utils import dnload_iter
+
+
+def separate32b(blob_size32b: int) -> (int, int):
+	"""
+	return a tuple containing (16bits MSB, 16bits LSB) of a 32bits int
+	"""
+	assert blob_size32b > 0
+	blob_size_16b_lsb = blob_size32b & 0xFFFF
+	blob_size_16b_msb = (blob_size32b >> 16) & 0xFFFF
+
+	return (blob_size_16b_msb, blob_size_16b_lsb)
+
+
+def send_blob(dev, blob: bytes) -> None:
+	"""
+	Send blob to dev. If blob is empty, do nothing, no USB exchanges.
+
+	Procedure is as follows:
+	1. CONTROL OUT size of blob to send
+	2. BULK send chunks of blob with chunck size of 16384 bytes.
+	"""
+	if len(blob) == 0:
+		err_msg = "Trying to send a blob of len 0"
+		logger.warning(err_msg)
+		return ValueError(err_msg)
+
+	blob_size = len(blob)
+	logger.debug(f"Sending blob of size {blob_size} bytes to {dev=}...")
+	(blob_size_16b_msb, blob_size_16b_lsb) = separate32b(blob_size)
+
+	# First CONTROL OUT indicates the number of bytes that will be
+	# transfered in the next BULKs transfers.
+	dev.ctrl_transfer(
+		bmRequestType=0x40,
+		bRequest=0,
+		wValue=blob_size_16b_lsb,
+		wIndex=blob_size_16b_msb,
+		data_or_wLength=0,
+	)
+
+	# we then send the blob in several bulk transfers
+	for chunk in dnload_iter(blob, 16384):
+		bulk_res = dev.write(1, chunk)
+		if bulk_res != len(chunk):
+			raise Exception(f"BULK OUT sent only {bulk_res}/{len(bulk_res)} bytes")
+
+
+def rom_code_send_file(dev, file_blob: bytes) -> int:
+	"""
+	Send a file_blob to the ROM code.
+
+	Procedure is as follows:
+	1. send_blob(size of file_blob)
+	2. send_blob(file_blob)
+	3. CONTROL IN: get transfer result from ROM Code, 0 == SUCCES
+
+	return transfer result from ROM Code, 0 == SUCCESS
+	"""
+	file_blob_size = len(file_blob)
+	logger.debug(f"Sending {file_blob_size=} bytes to ROM Code")
+	send_blob(dev, file_blob_size.to_bytes(24, "little", signed=False))
+
+	send_blob(dev, file_blob)
+
+	logger.debug("Waiting for ROM code to process file")
+	sleep(2)
+	ctrl_transfer_res = dev.ctrl_transfer(
+		bmRequestType=0xC0, bRequest=0, wValue=0x0004, wIndex=0, data_or_wLength=4
+	)
+	rom_code_status = int.from_bytes(
+		ctrl_transfer_res, byteorder="little", signed=False
+	)
+	logger.debug(f"ROM Code answered with {rom_code_status=}")
+
+	return rom_code_status
+
+
+class BootcodeCommand(enum.IntEnum):
+	GET_FILE_SIZE = 0
+	GET_FILE = 1
+	DONE = 2
+
+	def __repr__(self):
+		return f"{self.name}:{self.value}"
+
+	@classmethod
+	def _missing_(cls, value):
+		err_msg = f"Unsupported command '{value}'"
+		logger.critical(err_msg)
+		raise ValueError(err_msg)
+
+
+def bootcode_get_command(dev) -> (BootcodeCommand, str):
+	"""
+	Get next command from bootcode.
+
+	CONTROL IN: result on 260 bytes: 4bytes command int (little endian) and 256bytes file name
+
+	return (command, filename)
+	"""
+	ctrl_transfer_res = dev.ctrl_transfer(
+		bmRequestType=0xC0, bRequest=0, wValue=0x0104, wIndex=0, data_or_wLength=260
+	)
+
+	command = int.from_bytes(ctrl_transfer_res[0:4], byteorder="little", signed=False)
+	command = BootcodeCommand(command)
+	filename: str = ctrl_transfer_res[4:]
+	try:
+		filename = filename[0 : filename.index(0x00)]  # file name is null terminated
+	except ValueError as ve:
+		# index fails, filename is not null terminated
+		err_msg = "file name received from bootcode is not null terminated"
+		logger.critical(err_msg)
+		logger.debug(f"{err_msg} {filename=}")
+		ve.add_note(err_msg)
+		raise ve
+
+	filename = filename.tobytes().decode("ascii")
+
+	return (command, filename)
+
+
+def bootcode_send_file_size(dev, file_blob: bytes) -> None:
+	"""
+	Send file size to bootcode.
+
+	Procedure is as follows:
+	CONTROL OUT file_blob size
+	"""
+	file_blob_size = len(file_blob)
+	(file_blob_size_16b_msb, file_blob_size_16b_lsb) = separate32b(file_blob_size)
+
+	dev.ctrl_transfer(
+		bmRequestType=0x40,
+		bRequest=0,
+		wValue=file_blob_size_16b_lsb,
+		wIndex=file_blob_size_16b_msb,
+		data_or_wLength=0,
+	)
+
+
+def bootcode_send_file(dev, file_blob: bytes) -> None:
+	"""
+	Send file to bootcode.
+
+	Procedure is as follows:
+	send_blob(file_blob)
+	"""
+	send_blob(dev, file_blob)

--- a/src/snagrecover/recoveries/bcm.py
+++ b/src/snagrecover/recoveries/bcm.py
@@ -1,0 +1,23 @@
+import logging
+
+logger = logging.getLogger("snagrecover")
+from time import sleep
+from snagrecover.firmware.firmware import run_firmware
+from snagrecover.utils import get_usb
+from snagrecover.config import recovery_config
+
+
+def main():
+	# USB ENUMERATION
+	usb_path = recovery_config["usb_path"]
+	dev = get_usb(usb_path)
+
+	# Download bootcode
+	run_firmware(dev, "bootfiles", "bootcode")
+
+	logger.info("Waiting for bootcode to start...")
+	sleep(2)
+	dev = get_usb(usb_path)
+
+	# Serve firmwares to bootcode (will also serve firmwares "boot" and "u-boot")
+	run_firmware(dev, "bootfiles", "bootcode_firmwares")

--- a/src/snagrecover/supported_socs.yaml
+++ b/src/snagrecover/supported_socs.yaml
@@ -63,6 +63,10 @@ tested:
         family: stm32mp
   zynqmp:
         family: zynqmp
+  bcm2711:
+        family: bcm
+  bcm2712:
+        family: bcm
 untested:
   a10:
         family: sunxi

--- a/src/snagrecover/templates/bcm2711.yaml
+++ b/src/snagrecover/templates/bcm2711.yaml
@@ -1,0 +1,8 @@
+bootfiles:
+    path: bootfiles.bin
+boot:
+    path: boot.img
+config:
+    path: config.txt
+u-boot:
+    path: u-boot.bin

--- a/src/snagrecover/templates/bcm2712.yaml
+++ b/src/snagrecover/templates/bcm2712.yaml
@@ -1,0 +1,8 @@
+bootfiles:
+    path: bootfiles.bin
+boot:
+    path: boot.img
+config:
+    path: config.txt
+u-boot:
+    path: u-boot.bin

--- a/src/snagrecover/utils.py
+++ b/src/snagrecover/utils.py
@@ -245,6 +245,10 @@ def get_recovery(soc_family: str):
 		from snagrecover.recoveries.keembay import main as keembay_recovery
 
 		return keembay_recovery
+	elif soc_family == "bcm":
+		from snagrecover.recoveries.bcm import main as bcm_recovery
+
+		return bcm_recovery
 	else:
 		cli_error(f"unsupported board family {soc_family}")
 


### PR DESCRIPTION
This PR adds the support for Broadcom SoC's bcm2711 and bcm2712 in snagrecover.
It has been developed and tested using Raspberry Pi CM4 and CM5.

I use `pyfatfs` python module so I added it to the project dependencies.