### PR TITLE
snagrecover: fix am335x cleanup option silently dropping "Done" message

### DIFF
--- a/src/snagrecover/am335x_usb_setup.sh
+++ b/src/snagrecover/am335x_usb_setup.sh
@@ -99,7 +99,7 @@ while getopts "p:r:s:n:ch:" opt; do
     r) ROMUSB=$OPTARG;;
     s) SPLUSB=$OPTARG;;
     n) NETNS_NAME=$OPTARG;;
-    c) cleanup echo "Done"
+    c) cleanup && echo "Done"
       exit 0
       ;;
     h) print_usage


### PR DESCRIPTION
In the -c (cleanup) getopts branch, `echo "Done"` was passed as an argument to cleanup() instead of running as a separate command. The missing semicolon caused the message to never be printed.