### PR TITLE
Snagflash fastboot uboot fix bmap range reading

### DIFF
--- a/src/snagflash/fastboot_uboot.py
+++ b/src/snagflash/fastboot_uboot.py
@@ -318,11 +318,6 @@ fb-size: size in bytes of the Fastboot buffer, this can only be used to reduce
 				f"flashed {file_bytes_flashed}/{file_size if file_size < sys.maxsize else '?'} bytes"
 			)
 
-		if file_size < sys.maxsize and file_bytes_flashed < file_size:
-			raise ValueError(
-				f"Truncated flash, only {file_bytes_flashed} bytes were flashed instead of {file_size} bytes"
-			)
-
 	def flash_mtd_section(
 		self,
 		fb_addr: int,

--- a/src/snagflash/fastboot_uboot.py
+++ b/src/snagflash/fastboot_uboot.py
@@ -262,7 +262,7 @@ fb-size: size in bytes of the Fastboot buffer, this can only be used to reduce
 			full_size = (
 				os.path.getsize(path)
 				if get_compression_method(path) is None
-				else sys.maxint
+				else sys.maxsize
 			)
 			ranges.append((full_size, 0))
 


### PR DESCRIPTION
Hello,

I'm still experimenting Snagboot features on SK-TDA4VM board.
After successfully tested the DFU and UMS mode, the fasboot mode was more difficult.

Here is my findings.

Best regards,
Romain
