### PR TITLE
src/snagrecover/utils.py: import compression modules when needed

### DIFF
--- a/src/snagrecover/utils.py
+++ b/src/snagrecover/utils.py
@@ -16,15 +16,6 @@ from snagrecover.usb import SnagbootUSBContext
 import yaml
 import importlib.resources
 
-import lzma
-import bz2
-import gzip
-
-if sys.version_info >= (3, 14):
-	from compression import zstd
-else:
-	from backports import zstd
-
 from math import ceil
 
 USB_RETRIES = 9
@@ -61,12 +52,22 @@ def open_compressed_file(path: str, mode):
 	comp = get_compression_method(path)
 
 	if comp == "xz":
+		import lzma
+
 		file = lzma.open(path, mode)
 	elif comp == "bz2":
+		import bz2
+
 		file = bz2.open(path, mode)
 	elif comp == "gz":
+		import gzip
+
 		file = gzip.open(path, mode)
 	elif comp == "zst":
+		if sys.version_info >= (3, 14):
+			from compression import zstd
+		else:
+			from backports import zstd
 		file = zstd.open(path, mode)
 	else:
 		return open(path, mode)


### PR DESCRIPTION
Commit 4f98bdec5ebeb13d9f851f848c3bd0086ef31eeb ("snagflash: Support on-the-fly decompression of input files") and
f59c97141c04ba8f87e4e60c322705078398bb7a ("snagflash: Support on-the-fly decompression of zstd files") have added unconditional imports of lzma, bz2, gzip and zstd Python modules, even if compressed input files are not used.

Switch to dynamic imports where these modules are only imported on-demand. This allows to relax the need to have support for those modules in Python, which can be helpful in environments such as Buildroot where dependencies are kept to a minimum.


---
Note: this change has not been tested.