### PR TITLE
snagflash: add automatic sparse conversion for large images

### DIFF
--- a/docs/developers/android-sparse-file.md
+++ b/docs/developers/android-sparse-file.md
@@ -44,3 +44,50 @@ without always writing at the beginning of the partition.
 
 The solution is to use the ``CHUNK_TYPE_DONTCARE``, which will skip some blocks of the output
 partition in the beginning of the 2+ images.
+
+Each split fragment is a fully valid, self-contained sparse file:
+
+- its ``total_blks`` field in the sparse header always reports the full block
+  count of the *original*, unsplit image, not just the blocks contained in
+  that particular fragment;
+- it is prefixed with a ``CHUNK_TYPE_DONTCARE`` chunk covering every block
+  already written by previous fragments;
+- it is suffixed with a ``CHUNK_TYPE_DONTCARE`` chunk covering every block that
+  will be written by later fragments;
+- the total serialized size of the fragment (file header + all chunk headers +
+  payloads) never exceeds ``max-download-size``.
+
+## Splitting raw (non-sparse) files
+
+Raw binary files can also be split into a sequence of ``max-download-size``-bounded
+sparse fragments, using the exact same splitting algorithm described above.
+
+The raw file is treated as a single logical ``CHUNK_TYPE_RAW`` region spanning
+the whole image:
+
+```text
+total_blks = ceil(file_size / block_size)
+```
+
+where ``block_size`` defaults to 4096 bytes. This synthetic RAW region is fed
+into the same fragment-splitting logic used for real sparse files (prefix/suffix
+``CHUNK_TYPE_DONTCARE`` padding, header/overhead accounting bounded by
+``max-download-size``), so raw files gain automatic splitting support without
+needing any format conversion of the file on disk.
+
+If the raw file size is not a multiple of ``block_size``, the final block is
+transparently zero-padded up to the block boundary in the generated sparse
+payload only; the source file itself is never modified.
+
+This is implemented by ``snagrecover.protocols.fastboot.Fastboot.flash_image()``,
+which:
+
+1. Reads ``max-download-size`` from U-Boot (raises an error if it can't be read,
+   or if it is 0).
+2. If the file's size fits within ``max-download-size``, downloads and flashes
+   it directly with no splitting.
+3. Otherwise, detects whether the file is an Android sparse file (by checking
+   its magic cookie) or a raw binary file, and splits it accordingly:
+   sparse files are split with the existing chunk-parsing logic, raw files are
+   split via the synthetic single-RAW-region approach described above.
+4. Downloads and flashes each fragment in turn.

--- a/docs/snagflash.md
+++ b/docs/snagflash.md
@@ -41,6 +41,7 @@ download:<filepath>
 erase:<part>
 flash:<part>
 flash_sparse:<sparsefilepath>:<partition>
+flash_image:<filepath>:<partition>
 boot
 continue
 reboot
@@ -63,6 +64,16 @@ snagflash -P fastboot -p 0483:0afb -f download:boot.img -f flash:0:1 -f boot
 The ``flash_sparse`` command will download and flash a android sparse file with
 fastboot protocol. For details about the file format, see the [sparse file format
 partial documentation](developers/android-sparse-file.md).
+
+The ``flash_image`` command downloads and flashes an image file to a partition,
+transparently handling both raw binary files and android sparse files. It reads
+the ``max-download-size`` Fastboot variable from U-Boot: if the file fits within
+this size, it is downloaded and flashed directly with no splitting. If the file
+is bigger, it is automatically split into several android sparse fragments
+(each bounded by ``max-download-size``, headers included) which are downloaded
+and flashed one after another. This works for both raw binary files (which are
+converted to an equivalent single-region sparse image on the fly, with no
+change to the source file) and existing android sparse files.
 
 For more information on Fastboot commands, see the [fastboot
 specification](https://android.googlesource.com/platform/system/core/+/refs/heads/master/fastboot/README.md)

--- a/src/snagflash/android_sparse_file/utils.py
+++ b/src/snagflash/android_sparse_file/utils.py
@@ -23,12 +23,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import logging
+import os
 
 from snagflash.android_sparse_file.sparse import (
 	AndroidSparseFile,
 	AndroidChunkHeader,
 	SPARSE_CHUNKHEADER_LEN,
 	SPARSE_FILEHEADER_LEN,
+	DEFAULT_BLOCK_SIZE,
+	MAGIC,
 	CHUNK_TYPE_DONTCARE,
 	CHUNK_TYPE_RAW,
 	CHUNK_TYPE_FILL,
@@ -54,6 +57,46 @@ def chunk_type_name(chunk_type):
 	Return a human-readable name for a chunk type constant, for logging.
 	"""
 	return CHUNK_TYPE_NAMES.get(chunk_type, f"UNKNOWN(0x{chunk_type:04X})")
+
+
+def is_sparse_file(path):
+	"""
+	Check whether the file at 'path' is a valid Android sparse image, by
+	inspecting its magic cookie (first 4 bytes, little-endian).
+	"""
+	with open(path, "rb") as f:
+		magic_bytes = f.read(4)
+	if len(magic_bytes) < 4:
+		return False
+	magic = int.from_bytes(magic_bytes, byteorder="little")
+	return magic == MAGIC
+
+
+class ZeroPaddedReader:
+	"""
+	Wraps a raw binary file object so that read(n) always returns exactly n
+	bytes, zero-padding the final short read at true EOF.
+
+	This lets a raw (non-sparse) file be fed directly into
+	process_raw_chunk(), which normally expects to read exact,
+	block-aligned payloads out of a real Android sparse file. Raw files are
+	usually not a multiple of block_size, so the final block must be
+	zero-padded up to the block boundary. Once EOF has been reached, any
+	further reads return all zero bytes, as a safety net.
+	"""
+
+	def __init__(self, fd):
+		self.fd = fd
+		self.eof = False
+
+	def read(self, n):
+		if self.eof:
+			return b"\x00" * n
+		data = self.fd.read(n)
+		if len(data) < n:
+			self.eof = True
+			data += b"\x00" * (n - len(data))
+		return data
 
 
 class SplitFragmentState:
@@ -446,3 +489,84 @@ def split_streaming(path, dest, bufsize):
 
 	finally:
 		sparse_file.close()
+
+
+def split_streaming_raw(path, dest, bufsize, block_size=DEFAULT_BLOCK_SIZE):
+	"""
+	Generator that yields one split sparse file at a time, built from a raw
+	(non-sparse) binary image, for immediate processing.
+
+	The raw file is treated as a single logical CHUNK_TYPE_RAW region
+	spanning the whole image. This synthetic chunk is split into
+	bufsize-limited sparse fragments by reusing the exact same
+	process_raw_chunk()/flush_fragment() machinery used by split_streaming()
+	for real sparse files, so the resulting fragments have the same
+	guarantees:
+
+	- Every fragment's sparse header reports the full logical block count
+	of the entire raw image (not just the blocks it contains).
+	- Every fragment starts with a DONT_CARE prefix covering blocks already
+	flushed in earlier fragments, and ends with a DONT_CARE suffix
+	covering blocks that will be flushed in later fragments.
+	- Each fragment (header + prefix + RAW payload + suffix) never exceeds
+	bufsize bytes.
+
+	If the raw file size is not a multiple of block_size, the final block
+	is transparently zero-padded up to the block boundary (the padding only
+	exists in the generated sparse payload, the source file is untouched).
+
+	Args:
+		path: Path to input raw binary file
+		dest: Path for temporary output file (will be reused for each split)
+		bufsize: Maximum size for each output file
+		block_size: Sparse image block size in bytes (default: DEFAULT_BLOCK_SIZE)
+
+	Yields:
+		Path to each split file (same path, but content changes each iteration)
+	"""
+	file_size = os.path.getsize(path)
+	total_blks = (file_size + block_size - 1) // block_size  # ceil division
+
+	# Pre-flight validation: ensure bufsize can hold at least one block with all headers
+	min_required = (
+		SPARSE_FILEHEADER_LEN  # 28 bytes: file header
+		+ 2 * SPARSE_CHUNKHEADER_LEN  # 24 bytes: prefix + one data chunk header
+		+ block_size  # At least one block of data
+		+ SPARSE_CHUNKHEADER_LEN  # 12 bytes: suffix reserve
+	)
+	if bufsize <= min_required:
+		raise IOError(
+			f"Buffer size {bufsize} too small. Need at least {min_required} bytes "
+			f"to fit one {block_size}-byte block with headers"
+		)
+
+	blocks_done = 0
+	state = SplitFragmentState()
+
+	logger.debug(
+		f"Starting streaming raw split: total_blocks={total_blks}, block_size={block_size}"
+	)
+
+	# Synthesize a single RAW chunk header covering the entire raw image
+	header = AndroidChunkHeader()
+	header.type = CHUNK_TYPE_RAW
+	header.size = total_blks
+
+	with open(path, "rb") as raw_fd:
+		input_fd = ZeroPaddedReader(raw_fd)
+
+		raw_gen = process_raw_chunk(
+			input_fd, header, state, blocks_done, bufsize, block_size, dest, total_blks
+		)
+		while True:
+			try:
+				flushed_fragment = next(raw_gen)
+				yield flushed_fragment
+			except StopIteration as stop:
+				blocks_done = stop.value
+				break
+
+		# Final flush: emit any remaining staged chunks as the last fragment
+		frag = flush_fragment(state, dest, block_size, total_blks)
+		if frag:
+			yield frag

--- a/src/snagflash/fastboot.py
+++ b/src/snagflash/fastboot.py
@@ -114,6 +114,7 @@ def fastboot(args):
 		"oem_bootbus",
 		"reset",
 		"flash_sparse",
+		"flash_image",
 	}
 
 	for cmd in args.fastboot_cmd:

--- a/src/snagrecover/protocols/fastboot.py
+++ b/src/snagrecover/protocols/fastboot.py
@@ -24,7 +24,12 @@ import tempfile
 from typing import Optional, Union
 
 from snagrecover import utils
-from snagflash.android_sparse_file.utils import split_streaming
+from snagflash.android_sparse_file.utils import (
+	split_streaming,
+	split_streaming_raw,
+	is_sparse_file,
+)
+from snagflash.android_sparse_file.sparse import MAGIC
 
 import logging
 
@@ -239,11 +244,10 @@ class Fastboot:
 
 		self.dev.write(self.ep_out, packet, timeout=self.timeout)
 
-	def flash_sparse(self, args: str):
+	def get_max_download_size(self) -> int:
 		"""
-		Download and flash an android sparse file.
-		If the file is too big, it's splitting into
-		smaller android sparse files.
+		Read the "max-download-size" Fastboot variable from U-Boot.
+		Raises a FastbootError if it cannot be read, or if it is 0.
 		"""
 		try:
 			maxsize = int(self.getvar("max-download-size"), 0)
@@ -253,51 +257,33 @@ class Fastboot:
 			) from e
 		if maxsize == 0:
 			raise FastbootError("Fastboot variable max-download-size is 0")
-		arg_list = args.split(":", 1)
-		cnt = len(arg_list)
-		if cnt != 2:
-			raise FastbootError(
-				f"Wrong arguments count {cnt}, expected 2. Given {args}"
-			)
-		fname = arg_list[0]
-		if not os.path.exists(fname):
-			raise FastbootError(f"File {fname} does not exist")
+		return maxsize
 
-		# Verify the file is a valid Android sparse file by checking magic cookie
-		try:
-			with open(fname, "rb") as f:
-				magic_bytes = f.read(4)
-				if len(magic_bytes) < 4:
-					raise FastbootError(
-						f"File {fname} is too small to be a valid sparse file"
-					)
-				magic = int.from_bytes(magic_bytes, byteorder="little")
-				if magic != 0xED26FF3A:
-					raise FastbootError(
-						f"File {fname} is not a valid Android sparse file. "
-						f"Expected magic 0xED26FF3A, got 0x{magic:08X}"
-					)
-				logger.info(f"Verified {fname} is a valid Android sparse file")
-		except IOError as e:
-			raise FastbootError(f"Failed to read file {fname}: {e}") from e
+	def split_and_flash(self, splitter, fname: str, part: str, maxsize: int):
+		"""
+		Split 'fname' into a series of android sparse fragments (each no
+		bigger than 'maxsize') using the given 'splitter' generator
+		function, then download and flash each fragment in turn to 'part'.
 
-		part = arg_list[1]
+		'splitter' is expected to have the same signature/semantics as
+		split_streaming()/split_streaming_raw(): splitter(path, dest, bufsize)
+		is a generator yielding the path to each fragment file (dest, reused
+		and overwritten for every fragment).
 
-		# Use streaming approach to minimize memory usage
-		# Each split file is created, downloaded, flashed, and then reused for the next split
-		# This allows processing of arbitrarily large sparse files with constant memory usage
+		Each split file is created, downloaded, flashed, and then reused for
+		the next split. This allows processing of arbitrarily large images
+		with constant memory usage.
+		"""
 		with tempfile.TemporaryDirectory() as tmp:
-			temppath = os.path.join(tmp, "sparse.img")
+			temppath = os.path.join(tmp, "split.img")
 			try:
 				# Count total splits upfront for "split X/N" logging below
-				total_splits = sum(1 for _ in split_streaming(fname, temppath, maxsize))
+				total_splits = sum(1 for _ in splitter(fname, temppath, maxsize))
 
 				split_count = 0
-				logger.info(
-					f"Starting streaming sparse file flash ({total_splits} split(s))..."
-				)
+				logger.info(f"Starting streaming flash ({total_splits} split(s))...")
 
-				for split_file in split_streaming(fname, temppath, maxsize):
+				for split_file in splitter(fname, temppath, maxsize):
 					split_count += 1
 					logger.info(
 						f"Processing split {split_count}/{total_splits}: Downloading {split_file}"
@@ -327,4 +313,96 @@ class Fastboot:
 					f"Successfully flashed {split_count}/{total_splits} split file(s) to {part}"
 				)
 			except Exception as e:
-				raise FastbootError(f"Streaming sparse flash failed: {e}") from e
+				raise FastbootError(f"Streaming flash failed: {e}") from e
+
+	def flash_sparse(self, args: str):
+		"""
+		Download and flash an android sparse file.
+		If the file is too big, it's splitting into
+		smaller android sparse files.
+		"""
+		maxsize = self.get_max_download_size()
+
+		arg_list = args.split(":", 1)
+		cnt = len(arg_list)
+		if cnt != 2:
+			raise FastbootError(
+				f"Wrong arguments count {cnt}, expected 2. Given {args}"
+			)
+		fname = arg_list[0]
+		if not os.path.exists(fname):
+			raise FastbootError(f"File {fname} does not exist")
+
+		# Verify the file is a valid Android sparse file by checking magic cookie
+		try:
+			if not is_sparse_file(fname):
+				raise FastbootError(
+					f"File {fname} is not a valid Android sparse file, "
+					f"or is too small to be a valid sparse file. "
+					f"Expected magic 0x{MAGIC:08X}"
+				)
+			logger.info(f"Verified {fname} is a valid Android sparse file")
+		except IOError as e:
+			raise FastbootError(f"Failed to read file {fname}: {e}") from e
+
+		part = arg_list[1]
+
+		self.split_and_flash(split_streaming, fname, part, maxsize)
+
+	def flash_image(self, args: str):
+		"""
+		Download and flash an image file (raw binary or android sparse) to
+		a partition, handling both formats transparently:
+
+		1. Reads "max-download-size" from U-Boot (fails if unavailable or 0).
+		2. If the file fits within max-download-size, downloads and flashes
+		it directly, with no splitting required.
+		3. If the file is bigger than max-download-size:
+			- If it's an Android sparse file, it's split into smaller sparse
+			fragments (reusing the same logic as flash_sparse()).
+			- If it's a raw binary file, it's split by synthesizing a single
+			logical RAW region covering the whole image, then splitting
+			that into smaller sparse fragments the same way. This gives
+			raw files automatic splitting support that they otherwise
+			don't have with a plain download()+flash().
+
+		Each emitted fragment (sparse or raw-derived) is downloaded and
+		flashed in turn, with progress logged as "split X/N".
+		"""
+		arg_list = args.split(":", 1)
+		cnt = len(arg_list)
+		if cnt != 2:
+			raise FastbootError(
+				f"Wrong arguments count {cnt}, expected 2. Given {args}"
+			)
+		fname = arg_list[0]
+		part = arg_list[1]
+
+		if not os.path.exists(fname):
+			raise FastbootError(f"File {fname} does not exist")
+
+		maxsize = self.get_max_download_size()
+
+		filesize = os.path.getsize(fname)
+
+		if filesize <= maxsize:
+			logger.info(
+				f"File {fname} ({filesize} bytes) fits within "
+				f"max-download-size (0x{maxsize:x}), flashing directly"
+			)
+			self.download(fname)
+			self.flash(part)
+			return
+
+		if is_sparse_file(fname):
+			logger.info(
+				f"File {fname} is an Android sparse file, splitting to fit "
+				f"max-download-size (0x{maxsize:x})"
+			)
+			self.split_and_flash(split_streaming, fname, part, maxsize)
+		else:
+			logger.info(
+				f"File {fname} is a raw binary file, splitting into sparse "
+				f"fragments to fit max-download-size (0x{maxsize:x})"
+			)
+			self.split_and_flash(split_streaming_raw, fname, part, maxsize)


### PR DESCRIPTION
Snagflash already supports flashing Android sparse images. However, users currently need to convert raw images to sparse format using an external tool before flashing when the image size exceeds the target's Fastboot download limit (e.g. U-Boot's max download size).

To simplify the workflow, automatically convert raw images to Android sparse format during flashing and stream them as multiple sparse chunks. This allows large images to be flashed successfully without requiring the full image to fit within the target's download buffer and eliminates the need for an external sparse conversion step.