### PR TITLE
SECURITY.md: fix s/got/go/ typo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,5 @@ Security and bug fixes are applied to the main branch, and included in the next 
 ## Reporting a Vulnerability
 
 Vulnerabilities may be reported privately if necessary.
-On the official Snagboot GitHub repository, got to "Security and quality">"Report a vulnerability",
+On the official Snagboot GitHub repository, go to "Security and quality">"Report a vulnerability",
 and follow the instructions to submit a vulnerability report.


### PR DESCRIPTION
Commit 96db45435b ("Create SECURITY.md") added a typo, fix that.