### PR TITLE
snagrecover: zynqmp: refuse to extract FSBL from signed boot image

### DIFF
--- a/docs/snagrecover.md
+++ b/docs/snagrecover.md
@@ -485,9 +485,9 @@ configuration:
 Detailed instructions for building the required boot images can be found in the
 [Xilinx documentation](https://xilinx.github.io/Embedded-Design-Tutorials), in
 the "boot-and-configuration" section for ZynqMP SoCs. Please note that the
-first boot image containing only the FSBL and PMUFW should not be required, as
-Snagboot is capable of extracting a working first-stage boot image from the
-full boot image.
+first boot image containing only the FSBL and PMUFW is only required if the
+boot image is signed, as Snagboot is capable of extracting a working
+first-stage boot image from an unsigned full boot image.
 
 The following images are required for all ZynqMP SoCs:
 

--- a/src/snagrecover/firmware/zynqmp_fw.py
+++ b/src/snagrecover/firmware/zynqmp_fw.py
@@ -100,6 +100,10 @@ def drop_images(boot_bin: bytearray, keep_images):
 
 	img_table_offset = find_img_table(boot_bin)
 	img_table = ZynqMPImageTable.read(boot_bin, img_table_offset)
+	if img_table.auth_cert != 0:
+		raise ValueError(
+			"Cannot extract FSBL stage from a signed image, provide a custom FSBL image"
+		)
 
 	kept_images = []
 	next_image = 4 * img_table.image_hdr


### PR DESCRIPTION
The logic to extract the 1st stage FSBL image from the full boot image only works if the boot image is not signed (as otherwise the signature validation will fail on the edited image, leading to boot failures).

Detect this and warn the user to use a custom FSBL image instead.